### PR TITLE
Fix sx126x_getDeviceErrors to read 3 bytes from response

### DIFF
--- a/src/SX126x_driver.cpp
+++ b/src/SX126x_driver.cpp
@@ -374,9 +374,9 @@ void sx126x_resetStats()
 
 void sx126x_getDeviceErrors(uint16_t* opError)
 {
-    uint8_t buf[2];
-    sx126x_transfer(0x17, buf, 2);
-    *opError = buf[1];
+    uint8_t buf[3];
+    sx126x_transfer(0x17, buf, 3);
+    *opError = buf[2];
 }
 
 void sx126x_clearDeviceErrors()


### PR DESCRIPTION
GetDeviceErrors incorrect read in SX126x and LLCC68